### PR TITLE
Fixed broken 'Submit a Status Update' link

### DIFF
--- a/src/components/InfoBox.js
+++ b/src/components/InfoBox.js
@@ -99,6 +99,12 @@ const InfoBox = (props) => {
         )
     }
 
+    const updateUrl = (id) => {
+        return(
+          `${config.api.dataEntryPortal}/shelters/${id}/edit`
+        )
+    }
+
     return (
         <div className={ toggledInfo ? 'info-box open' : 'info-box'}>
             <h2>{highlightText(shelter)}</h2>
@@ -115,7 +121,7 @@ const InfoBox = (props) => {
                 </p>
                 <p><FaRefresh className="blueIcon" />
                     <a className="update-shelter-button" target="_blank"
-                       href={`${config.api.baseURL}/${id}/edit`} style={{fontWeight: 'bold'}}>Submit a Status Update</a></p>
+                       href={updateUrl(id)} style={{fontWeight: 'bold'}}>Submit a Status Update</a></p>
                 <br/>
                 <p><span style={{fontWeight: 'bold'}}>Updated:</span> {moment(lastUpdated).format('L LT')}</p>
                 <p><span style={{fontWeight: 'bold'}}>Accepting People?</span> {accepting ? 'Yes' : 'No' }</p>


### PR DESCRIPTION
Fixed this link here:

<img width="533" alt="hurricane_irma_shelters_in_florida" src="https://user-images.githubusercontent.com/9599/30326429-60fb3b24-977d-11e7-8c0d-de0118576373.png">

It was linking to this page, which 404s:

    https://irma-api.herokuapp.com/api/v1/shelters/1171/edit

I've fixed it to link to this instead:

    https://irma-api.herokuapp.com/shelters/1171/edit
